### PR TITLE
Adding Precise Direction Arrow

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -71,6 +71,7 @@ export function Game({ settingsData }: GameProps) {
       const newGuess = {
         name: currentGuess,
         distance: geolib.getDistance(guessedCountry, country),
+        preciseDirection: geolib.getRhumbLineBearing(guessedCountry, country),
         direction: geolib.getCompassDirection(
           guessedCountry,
           country,

--- a/src/components/GuessRow.tsx
+++ b/src/components/GuessRow.tsx
@@ -2,7 +2,6 @@ import {
   computeProximityPercent,
   formatDistance,
   generateSquareCharacters,
-  getDirectionEmoji,
 } from "../domain/geography";
 import { Guess } from "../domain/guess";
 import React, { useCallback, useEffect, useState } from "react";
@@ -99,7 +98,15 @@ export function GuessRow({
             {guess && formatDistance(guess.distance, distanceUnit)}
           </div>
           <div className="flex items-center justify-center border-2 h-8 col-span-1 animate-reveal">
-            {guess && <Twemoji text={getDirectionEmoji(guess)} />}
+            {guess && (
+              <span
+                style={{
+                  transform: `rotate(${guess.preciseDirection - 90}deg)`,
+                }}
+              >
+                ➜
+              </span>
+            )}
           </div>
           <div className="flex items-center justify-center border-2 h-8 col-span-1 animate-reveal animate-pop">
             {`${proximity}%`}

--- a/src/components/panels/Infos.tsx
+++ b/src/components/panels/Infos.tsx
@@ -35,6 +35,7 @@ export function Infos({ isOpen, close, settingsData }: InfosProps) {
                 name: "Chile",
                 direction: "NE",
                 distance: 13_557_000,
+                preciseDirection: 55,
               },
             ]}
             settingsData={settingsData}
@@ -55,6 +56,7 @@ export function Infos({ isOpen, close, settingsData }: InfosProps) {
                 name: "Finland",
                 direction: "SE",
                 distance: 3_206_000,
+                preciseDirection: 167,
               },
             ]}
             settingsData={settingsData}
@@ -74,6 +76,7 @@ export function Infos({ isOpen, close, settingsData }: InfosProps) {
                 name: "Lebanon",
                 direction: "N",
                 distance: 0,
+                preciseDirection: 0,
               },
             ]}
             settingsData={settingsData}

--- a/src/components/panels/InfosFr.tsx
+++ b/src/components/panels/InfosFr.tsx
@@ -36,6 +36,7 @@ export function InfosFr({ isOpen, close, settingsData }: InfosProps) {
                 name: "Chili",
                 direction: "NE",
                 distance: 13_557_000,
+                preciseDirection: 55,
               },
             ]}
             settingsData={settingsData}
@@ -56,6 +57,7 @@ export function InfosFr({ isOpen, close, settingsData }: InfosProps) {
                 name: "Finlande",
                 direction: "SE",
                 distance: 3_206_000,
+                preciseDirection: 167,
               },
             ]}
             settingsData={settingsData}
@@ -76,6 +78,7 @@ export function InfosFr({ isOpen, close, settingsData }: InfosProps) {
                 name: "Liban",
                 direction: "N",
                 distance: 0,
+                preciseDirection: 0,
               },
             ]}
             settingsData={settingsData}

--- a/src/domain/guess.ts
+++ b/src/domain/guess.ts
@@ -3,6 +3,7 @@ import { Direction } from "./geography";
 export interface Guess {
   name: string;
   distance: number;
+  preciseDirection: number;
   direction: Direction;
 }
 


### PR DESCRIPTION
Instead of a `N, NE, E, SE, S, SW, W, NW` direction arrow, this PR provides a precise arrow direction based on heading...

---

Au lieu d'une flèche de direction `N, NE, E, SE, S, SW, W, NW`, ce PR fournit une direction de flèche précise basée sur le cap ...

<img width="545" alt="Screen Shot 2022-03-05 at 9 58 08 AM" src="https://user-images.githubusercontent.com/1092915/156888735-1cf72b2f-4d33-4df8-a7d1-fff73588cf23.png">


### Works in Light Mode Too

<img width="523" alt="Screen Shot 2022-03-05 at 8 57 14 AM" src="https://user-images.githubusercontent.com/1092915/156886513-05b6aa9a-20ee-4ec7-8b43-04935a25797a.png">
