### PR TITLE
Add the ability to revert to system color theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,8 @@ function App({
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [statsOpen, setStatsOpen] = useState(false);
 
-  const [settingsData, updateSettings] = useSettings();
+  const [settingsData, settingsStorageData, updateSettingsStorageData] =
+    useSettings();
 
   useEffect(() => {
     if (newServiceWorkerDetected) {
@@ -86,8 +87,8 @@ function App({
       <Settings
         isOpen={settingsOpen}
         close={() => setSettingsOpen(false)}
-        settingsData={settingsData}
-        updateSettings={updateSettings}
+        settingsData={settingsStorageData}
+        updateSettings={updateSettingsStorageData}
       />
       <Stats
         isOpen={statsOpen}
@@ -125,7 +126,10 @@ function App({
               <Twemoji text="⚙️" />
             </button>
           </header>
-          <Game settingsData={settingsData} updateSettings={updateSettings} />
+          <Game
+            settingsData={settingsData}
+            updateSettings={updateSettingsStorageData}
+          />
           <footer className="flex justify-center items-center text-sm mt-8 mb-1">
             <Twemoji
               text="❤️"

--- a/src/components/panels/Settings.tsx
+++ b/src/components/panels/Settings.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { SettingsData } from "../../hooks/useSettings";
+import { SettingsStorageData } from "../../hooks/useSettings";
 import { Panel } from "./Panel";
 
 interface SettingsProps {
   isOpen: boolean;
   close: () => void;
-  settingsData: SettingsData;
-  updateSettings: (newSettings: Partial<SettingsData>) => void;
+  settingsData: SettingsStorageData;
+  updateSettings: (newSettings: Partial<SettingsStorageData>) => void;
 }
 
 export function Settings({
@@ -50,11 +50,17 @@ export function Settings({
           <select
             id="setting-theme"
             className="h-8 dark:bg-slate-800"
-            value={settingsData.theme}
+            value={settingsData.themePreference}
             onChange={(e) =>
-              updateSettings({ theme: e.target.value as "light" | "dark" })
+              updateSettings({
+                themePreference: e.target.value as
+                  | "light"
+                  | "dark"
+                  | "no-preference",
+              })
             }
           >
+            <option value="no-preference">System</option>
             <option value="light">Light</option>
             <option value="dark">Dark</option>
           </select>

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 export interface SettingsData {
   noImageMode: boolean;
@@ -9,18 +9,20 @@ export interface SettingsData {
   allowShiftingDay: boolean;
 }
 
-const defaultSettingsData: SettingsData = {
+export type SettingsStorageData = Omit<SettingsData, "theme"> & {
+  themePreference: "light" | "dark" | "no-preference";
+};
+
+const defaultSettingsData: SettingsStorageData = {
   noImageMode: false,
   rotationMode: false,
   distanceUnit: "km",
-  theme: window.matchMedia("(prefers-color-scheme: dark)").matches
-    ? "dark"
-    : "light",
+  themePreference: "no-preference",
   shiftDayCount: 0,
   allowShiftingDay: false,
 };
 
-function loadSettings(): SettingsData {
+function loadSettings(): SettingsStorageData {
   const storedSettings = localStorage.getItem("settings");
   const settingsData = storedSettings != null ? JSON.parse(storedSettings) : {};
   return {
@@ -28,27 +30,37 @@ function loadSettings(): SettingsData {
     ...settingsData,
   };
 }
-
 export function useSettings(): [
   SettingsData,
-  (newSettings: Partial<SettingsData>) => void
+  SettingsStorageData,
+  (newSettings: Partial<SettingsStorageData>) => void
 ] {
-  const [settingsData, setSettingsData] = useState<SettingsData>(
-    loadSettings()
-  );
+  const [settingsStorageData, setSettingsStorageData] =
+    useState<SettingsStorageData>(loadSettings());
 
-  const updateSettingsData = useCallback(
-    (newSettings: Partial<SettingsData>) => {
+  const settingsData = useMemo(() => {
+    const { themePreference, ...settingsData } = settingsStorageData;
+    const theme =
+      themePreference === "no-preference"
+        ? window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light"
+        : themePreference;
+    return { ...settingsData, theme };
+  }, [settingsStorageData]);
+
+  const updateSettingsStorageData = useCallback(
+    (newSettings: Partial<SettingsStorageData>) => {
       const updatedSettings = {
-        ...settingsData,
+        ...settingsStorageData,
         ...newSettings,
       };
 
-      setSettingsData(updatedSettings);
+      setSettingsStorageData(updatedSettings);
       localStorage.setItem("settings", JSON.stringify(updatedSettings));
     },
-    [settingsData]
+    [settingsStorageData]
   );
 
-  return [settingsData, updateSettingsData];
+  return [settingsData, settingsStorageData, updateSettingsStorageData];
 }


### PR DESCRIPTION
In the settings panel, once you change any setting, it's not possible to revert back to using the system color theme. (You can tell macOS to switch to dark mode after sunset, for example, in which case being unable to use it is not nice.)

This PR adds the option to choose "System" as the theme preference. To achieve this, I had to separate stored settings and computed settings types. I hope this was not too invasive, but seemed like the cleanest option.

Great game by the way, I play daily!