### PR TITLE
no-repeat picking date diff was reversed

### DIFF
--- a/src/hooks/useTodays.ts
+++ b/src/hooks/useTodays.ts
@@ -137,8 +137,8 @@ function isARepeat(
   if (pickedCountry == null || lastPickDates[pickedCountry.code] == null) {
     return false;
   }
-  const daysSinceLastPick = lastPickDates[pickedCountry.code].diff(
-    currentDayDate,
+  const daysSinceLastPick = currentDayDate.diff(
+    lastPickDates[pickedCountry.code],
     "day"
   ).days;
 


### PR DESCRIPTION
The "when was this last repeated" date calculation was inverted, meaning
any country on the repeat list will be forever seen as a repeat. (i.e.
it'll always be negative, therefore always less than 100.)