### PR TITLE
Fix language code for portuguese

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -372,7 +372,7 @@ export const translations = {
       },
     },
   },
-  br: {
+  pt: {
     translation: {
       placeholder: "País, território...",
       guess: "Adivinhar",


### PR DESCRIPTION
br is the language code for Breton. pt is for Portuguese (Brazilian or from Portugal)