### PR TITLE
Remove ambiguity from instructions

### DIFF
--- a/src/components/panels/Infos.tsx
+++ b/src/components/panels/Infos.tsx
@@ -22,7 +22,7 @@ export function Infos({ isOpen, close, settingsData }: InfosProps) {
         <div>Each guess must be a valid country, territory, ...</div>
         <div>
           After each guess, you will have the distance, the direction and the
-          proximity from your guess to the target country.
+          proximity from your guess to the target location.
         </div>
       </div>
       <div className="space-y-3 text-justify border-b-2 border-gray-200 pb-3 mb-3">

--- a/src/components/panels/Infos.tsx
+++ b/src/components/panels/Infos.tsx
@@ -42,7 +42,7 @@ export function Infos({ isOpen, close, settingsData }: InfosProps) {
           <div className="my-2">
             Your guess <span className="uppercase font-bold">Chile</span> is{" "}
             {formatDistance(13557000, settingsData.distanceUnit)} away from the
-            target country, the target country is in the North-East direction
+            target location, the target location is in the North-East direction
             and you have a only 32% of proximity because it&apos;s quite far
             away!
           </div>
@@ -80,7 +80,7 @@ export function Infos({ isOpen, close, settingsData }: InfosProps) {
           />
           <div className="my-2">
             Next guess, <span className="uppercase font-bold">Lebanon</span>,
-            it&apos;s the country to guess! Congrats!{" "}
+            it&apos;s the location to guess! Congrats!{" "}
             <Twemoji text="🎉" options={{ className: "inline-block" }} />
           </div>
         </div>


### PR DESCRIPTION
There are inconsistencies in the instructions; the first line states that the location is a country, territory, ... 

But the following one states that the "country" -- this PR irons out that inconsistency.